### PR TITLE
Fix build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <version>106</version>
     </parent>
 
-    <groupId>rocks.trino</groupId>
+    <groupId>kokosing.trino</groupId>
     <artifactId>trino-query-formatter</artifactId>
     <version>0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -81,7 +81,7 @@
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
-                                        <Main-Class>rocks.trino.query.formatter.Main</Main-Class>
+                                        <Main-Class>kokosing.trino.query.formatter.Main</Main-Class>
                                     </manifestEntries>
                                 </transformer>
                             </transformers>

--- a/src/main/java/kokosing/trino/query/formatter/Main.java
+++ b/src/main/java/kokosing/trino/query/formatter/Main.java
@@ -30,6 +30,12 @@ public class Main
 {
     private static final SqlParser SQL_PARSER = new SqlParser();
 
+    protected Main()
+    {
+        // prevents calls from subclass
+        throw new UnsupportedOperationException();
+    }
+
     public static void main(String[] args)
             throws IOException
     {


### PR DESCRIPTION
Building with `./mvnw clean install` was failing with:
```
[INFO] --- maven-checkstyle-plugin:3.1.1:check (checkstyle) @ trino-query-formatter ---
[INFO] There is 1 error reported by Checkstyle 8.32 with checkstyle/airbase-checks.xml ruleset.
[ERROR] src/main/java/kokosing/trino/query/formatter/Main.java:[29,1] (design) HideUtilityClassConstructor: Utility classes should not have a public or default constructor.
```

and after disabling checkstyle the JAR couldn't be executed because of:
```
Error: Could not find or load main class rocks.trino.query.formatter.Main
Caused by: java.lang.ClassNotFoundException: rocks.trino.query.formatter.Main
```