### PR TITLE
Migrate from travis-ci to github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+---
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "maven" 
+    directory: "/" 
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -1,13 +1,13 @@
 ---
-name: Java CI (autogen)
+name: Java CI
 
 on:
   push:
     branches:
-      - development
+      - master
   pull_request:
     branches:
-      - development
+      - master
 
 jobs:
   build:
@@ -27,14 +27,6 @@ jobs:
       with:
         java-version: ${{ matrix.java-version }}
         distribution: 'temurin'
-
-    # # - name: Run mvn install
-    # #   run: |
-    # #     ./mvnw -B install -DskipTests -Dmaven.javadoc.skip=true -Dair.check.skip-all=true
-
-    # - name: Run tests
-    #   run: |
-    #     ./mvnw test -B
 
     - name: Build with Maven
       run: ./mvnw -B clean install -DskipTests

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -1,0 +1,40 @@
+---
+name: Java CI (autogen)
+
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: ['17.0.7+7']
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up JDK
+      uses: actions/setup-java@v2
+      with:
+        java-version: ${{ matrix.java-version }}
+        distribution: 'temurin'
+
+    # # - name: Run mvn install
+    # #   run: |
+    # #     ./mvnw -B install -DskipTests -Dmaven.javadoc.skip=true -Dair.check.skip-all=true
+
+    # - name: Run tests
+    #   run: |
+    #     ./mvnw test -B
+
+    - name: Build with Maven
+      run: ./mvnw -B clean install -DskipTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: java
-dist: trusty
-sudo: false


### PR DESCRIPTION
## Overview

- Migrate from travis-ci to github actions
- Add dependabot.yaml to update Github actions dependencies